### PR TITLE
DE-904 - public function to only download and parse the manifest

### DIFF
--- a/src/asset-services.test.ts
+++ b/src/asset-services.test.ts
@@ -214,6 +214,36 @@ describe(AssetServices.name, () => {
       ).toHaveBeenCalled();
     });
   });
+
+  describe("getEntrypoints", () => {
+    it("should request for the manifest and parse the entrypoints", async () => {
+      // Arrange
+      const manifestURL =
+        "https://cdn.fromdoppler.com/test/asset-manifest-v1.json";
+      const responseJson = {
+        entrypoints: [
+          "static/css/main.e6c13ad2.css",
+          "static/js/main.cf47d9fd.js",
+          "https://absolute/file3.css",
+        ],
+      };
+      const expectedEntrypointsUrls = [
+        "https://cdn.fromdoppler.com/test/static/css/main.e6c13ad2.css",
+        "https://cdn.fromdoppler.com/test/static/js/main.cf47d9fd.js",
+        "https://absolute/file3.css",
+      ];
+      const windowMoq = createWindowMoq(responseJson);
+      const instance = new AssetServices(windowMoq as any);
+
+      // Act
+      const result = await instance.getEntrypoints({ manifestURL });
+
+      // Assert
+      expect(windowMoq.fetch).toHaveBeenCalledTimes(1);
+      expect(windowMoq.fetch).toHaveBeenCalledWith(manifestURL);
+      expect(result).toEqual(expectedEntrypointsUrls);
+    });
+  });
 });
 
 function createWindowMoq(responseJson: { entrypoints: string[] }) {

--- a/src/asset-services.ts
+++ b/src/asset-services.ts
@@ -14,6 +14,23 @@ async function getEntrypoints({
   return entrypoints;
 }
 
+function addEntrypointReferencesToDOM({
+  document,
+  entrypoints,
+  referenceNode,
+}: {
+  document: Document;
+  entrypoints: string[];
+  referenceNode: Node;
+}): void {
+  entrypoints
+    .map((entrypoint) => createElement({ document, entrypoint }))
+    .filter((x): x is HTMLElement => !!x)
+    .forEach((element) => {
+      addElementBefore({ element, referenceNode });
+    });
+}
+
 function ensureAbsoluteURLs(baseURL: string, entrypoints: string[]) {
   const regExpIsAbsoluteURL = new RegExp("^(?:[a-z]+:)?//", "i");
   return entrypoints.map(function (entrypoint) {
@@ -77,14 +94,9 @@ async function load({
   // Consider using Loggly
   // Consider applying retries
   // Consider allowing run fallback code
-  const entrypoints = await getEntrypoints({ fetch, manifestURL });
-  entrypoints
-    .concat(sources)
-    .map((entrypoint) => createElement({ document, entrypoint }))
-    .filter((x): x is HTMLElement => !!x)
-    .forEach((element) => {
-      addElementBefore({ element, referenceNode });
-    });
+  const manifestEntrypoints = await getEntrypoints({ fetch, manifestURL });
+  const entrypoints = manifestEntrypoints.concat(sources);
+  addEntrypointReferencesToDOM({ document, entrypoints, referenceNode });
 }
 
 function normalizeArgs(

--- a/src/asset-services.ts
+++ b/src/asset-services.ts
@@ -132,6 +132,7 @@ interface IAssetServices {
     /** the new elements will be added before this one */
     referenceNode?: Node;
   }): Promise<void>;
+  getEntrypoints({ manifestURL }: { manifestURL: string }): Promise<string[]>;
 }
 
 export class AssetServices implements IAssetServices {
@@ -172,6 +173,17 @@ export class AssetServices implements IAssetServices {
       manifestURL,
       sources,
       referenceNode,
+    });
+  }
+
+  async getEntrypoints({
+    manifestURL,
+  }: {
+    manifestURL: string;
+  }): Promise<string[]> {
+    return getEntrypoints({
+      fetch: this._fetch,
+      manifestURL,
     });
   }
 }

--- a/src/asset-services.ts
+++ b/src/asset-services.ts
@@ -1,3 +1,19 @@
+async function getEntrypoints({
+  fetch,
+  manifestURL,
+}: {
+  fetch: (input: RequestInfo, init?: RequestInit) => Promise<Response>;
+  manifestURL: string;
+}): Promise<string[]> {
+  const response = await fetch(manifestURL);
+  const data = await response.json();
+  const entrypoints = ensureAbsoluteURLs(
+    manifestURL.substring(0, manifestURL.lastIndexOf("/") + 1),
+    data.entrypoints
+  );
+  return entrypoints;
+}
+
 function ensureAbsoluteURLs(baseURL: string, entrypoints: string[]) {
   const regExpIsAbsoluteURL = new RegExp("^(?:[a-z]+:)?//", "i");
   return entrypoints.map(function (entrypoint) {
@@ -61,12 +77,7 @@ async function load({
   // Consider using Loggly
   // Consider applying retries
   // Consider allowing run fallback code
-  const response = await fetch(manifestURL);
-  const data = await response.json();
-  const entrypoints = ensureAbsoluteURLs(
-    manifestURL.substring(0, manifestURL.lastIndexOf("/") + 1),
-    data.entrypoints
-  );
+  const entrypoints = await getEntrypoints({ fetch, manifestURL });
   entrypoints
     .concat(sources)
     .map((entrypoint) => createElement({ document, entrypoint }))


### PR DESCRIPTION
I want to reuse the manifest parsing without the DOM manipulation in Editors WebApp to avoid using the loader inside Unlayer IFrame to load the Unlayer Editor extensions.

Could you review it?