### PR TITLE
Support module type

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ interface IAssetServices {
 
 - `sources`: A optional list of JavaScript or CSS resources that will be loaded after the files referenced in the _asset-manifest_.
 
+- `referenceNode` (missing documentation)
+
+- `options` (missing documentation)
+
 **Result:**
 
 It returns a promise. The promise is fulfilled when the _asset-manifest_ is loaded and the DOM updated. It does not warrant that the files referenced in the _asset-manifest_ have been loaded yet.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mfe-loader",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "6.4.5",


### PR DESCRIPTION
We have a scenario where we need to render `<script src="..." type="module">`. Probably, it should depend on data from the manifest, but, for the moment this quick and dirty fix should work.
